### PR TITLE
Fix Issue with Perl Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# CGPSA - A Spam Filter for CommuniGate (R) Pro - Version 1.8.1
-## Copyright (C) 2002-2022 TFF Enterprises, Written by Daniel M. Zimmerman
+# CGPSA - A Spam Filter for CommuniGate (R) Pro - Version 1.8.2
+## Copyright (C) 2002-2023 TFF Enterprises, Written by Daniel M. Zimmerman
 
 License information is located in [LICENSE.md](LICENSE.md), and usage and
 installation documentation is located in 

--- a/cgpsa
+++ b/cgpsa
@@ -1,7 +1,7 @@
 #!/usr/local/bin/perl
 
-# CGPSA - A Spam Filter for CommuniGate Pro - Version 1.8.1
-# Copyright (C) 2002-2022 TFF Enterprises
+# CGPSA - A Spam Filter for CommuniGate Pro - Version 1.8.2
+# Copyright (C) 2002-2023 TFF Enterprises
 # Written by Daniel M. Zimmerman
 #
 # This CommuniGate Pro filter uses SpamAssassin technology to scan messages
@@ -119,7 +119,7 @@ $SIG{'HUP'} = \&signalHUP;
 
 # Version string for this filter.
 
-our $VERSION = "1.8.1";
+our $VERSION = "1.8.2";
 
 # Version information header to be added to messages (includes platform,
 # perl version, hostname; primarily used for debugging)
@@ -1996,7 +1996,7 @@ sub process_file
 
       if (defined($return_path_route) && 
           ($return_path_route->[0] eq "LOCAL") && 
-          ($return_path_route->[1] eq %$list_settings{"Owner"})) 
+          ($return_path_route->[1] eq $list_settings->{"Owner"})) 
       {
         debug(4, "Accepting message to mailing list " . $list_address . 
                  " from owner.");
@@ -2005,7 +2005,7 @@ sub process_file
 
       # if the list only allows posting from the owner, reject the message
 
-      if (%$list_settings{"Postings"} eq "from owner")
+      if ($list_settings->{"Postings"} eq "from owner")
       {
         if ($cli)
         {
@@ -2021,8 +2021,8 @@ sub process_file
       # if the list allows postings from "anybody" or "moderate guests", 
       # allow the message
 
-      if ((%$list_settings{"Postings"} eq "anybody") ||
-          (%$list_settings{"Postings"} eq "moderate guests")) 
+      if (($list_settings->{"Postings"} eq "anybody") ||
+          ($list_settings->{"Postings"} eq "moderate guests")) 
       {
         debug(4, "Accepting message to mailing list " . $list_address . 
                  " with permissive post policy.");
@@ -2032,8 +2032,8 @@ sub process_file
       # check the subscription status
 
       my $subscriber_info = $cli->GetSubscriberInfo($list_address, $return_path);
-      if (%$subscriber_info{"ConfirmationID"} &&
-          (%$subscriber_info{"posts"} ne "prohibited"))
+      if ($subscriber_info->{"ConfirmationID"} &&
+          ($subscriber_info->{"posts"} ne "prohibited"))
       {
         # at this point, it's a legit mailing list subscriber that isn't 
         # prohibited from posting

--- a/documentation.html
+++ b/documentation.html
@@ -8,8 +8,8 @@
 <link rel="stylesheet" href="style.css" type="text/css" media="screen" />
 </head>
 <body>
-<h1>CGPSA - A Spam Filter for <a href="http://www.communigate.com/CommuniGatePro/">CommuniGate&reg; Pro</a><br/>Version 1.8.1</h1>
-<h2>Copyright &copy; 2002-2022 TFF Enterprises<br/>
+<h1>CGPSA - A Spam Filter for <a href="http://www.communigate.com/CommuniGatePro/">CommuniGate&reg; Pro</a><br/>Version 1.8.2</h1>
+<h2>Copyright &copy; 2002-2023 TFF Enterprises<br/>
 Written by <a href="https://www.tffenterprises.com/~dmz/">Daniel M. Zimmerman</a></h2>
 
 <p>CGPSA works in concert with <a
@@ -42,8 +42,8 @@ details.</p>
 from <a href="https://www.tffenterprises.com/cgpsa/cgpsa.tgz">
 https://www.tffenterprises.com/cgpsa/cgpsa.tgz</a>. The current (release)
 version is <a
-href="https://www.tffenterprises.com/cgpsa/releases/cgpsa-1_8_1.tgz">1.8.1</a>, 
-released 22 January 2022.</p>
+href="https://www.tffenterprises.com/cgpsa/releases/cgpsa-1_8_2.tgz">1.8.2</a>, 
+released 17 June 2023.</p>
 
 <p>There is no current testing version of CGPSA.</p>
 
@@ -401,6 +401,15 @@ file).</p>
 <h3 id="history">Revision History</h3>
 
 <dl>
+
+<dt><a href="https://www.tffenterprises.com/cgpsa/release/cgpsa-1_8_2.tgz">1.8.2</a> - 17 June 2023</dt>
+<dd>
+<p>Bug Fixes</p>
+<ul>
+
+<li>Fixed some Perl syntax that did not work properly with more recent versions of Perl. (https://github.com/TFF-Enterprises/CGPSA/issues/3).</li>
+</ul>
+</dd>
 
 <dt><a href="https://www.tffenterprises.com/cgpsa/releases/cgpsa-1_8_1.tgz">1.8.1</a> - 22 January 2022</dt>
 <dd>


### PR DESCRIPTION
As noted in #3, the current version of CGPSA has a syntax issue with later versions of Perl. This PR should fix that.

Closes #3